### PR TITLE
feat: implementar asignación de productos WooCommerce a bodegas

### DIFF
--- a/multistock-backend/README_WOOCOMMERCE_WAREHOUSE.md
+++ b/multistock-backend/README_WOOCOMMERCE_WAREHOUSE.md
@@ -1,0 +1,357 @@
+# Gestión de Productos WooCommerce y Bodegas
+
+Este documento describe las funcionalidades implementadas para asignar productos de WooCommerce a bodegas y gestionar el stock.
+
+## Funcionalidades Implementadas
+
+### 1. Asignación de Productos WooCommerce a Bodegas
+
+#### 1.1 Asignar Producto Existente a Bodega
+**Endpoint:** `POST /api/woocommerce/woo/{storeId}/product/{productId}/assign-warehouse`
+
+Asigna un producto existente de WooCommerce a una bodega específica.
+
+**Parámetros de URL:**
+- `storeId`: ID de la tienda WooCommerce
+- `productId`: ID del producto en WooCommerce
+
+**Body de la petición:**
+```json
+{
+    "warehouse_id": 1,
+    "available_quantity": 100,
+    "price": 29.99,
+    "condicion": "new",
+    "currency_id": "CLP",
+    "listing_type_id": "gold_special",
+    "category_id": "MLB1234",
+    "attribute": {
+        "color": "rojo",
+        "size": "M"
+    },
+    "pictures": [
+        {"src": "https://example.com/image1.jpg"},
+        {"src": "https://example.com/image2.jpg"}
+    ],
+    "sale_terms": [
+        {"id": "WARRANTY_TYPE", "value_name": "Garantía del vendedor"}
+    ],
+    "shipping": {
+        "mode": "me2",
+        "free_shipping": true
+    },
+    "description": "Descripción del producto"
+}
+```
+
+**Respuesta exitosa:**
+```json
+{
+    "message": "Producto asignado correctamente a la bodega.",
+    "stock_warehouse": {
+        "id": 1,
+        "id_mlc": "12345",
+        "warehouse_id": 1,
+        "title": "Producto Ejemplo",
+        "price": 29.99,
+        "available_quantity": 100,
+        "condicion": "new",
+        "currency_id": "CLP",
+        "listing_type_id": "gold_special"
+    },
+    "woo_product": {
+        "id": 12345,
+        "name": "Producto Ejemplo",
+        "type": "simple",
+        "status": "publish",
+        "price": "29.99"
+    },
+    "status": "success"
+}
+```
+
+#### 1.2 Crear Producto y Asignar a Bodega
+**Endpoint:** `POST /api/woocommerce/woo/{storeId}/product-create-assign-warehouse`
+
+Crea un nuevo producto en WooCommerce y lo asigna a una bodega en una sola operación.
+
+**Parámetros de URL:**
+- `storeId`: ID de la tienda WooCommerce
+
+**Body de la petición:**
+```json
+{
+    "name": "Nuevo Producto",
+    "type": "simple",
+    "regular_price": "29.99",
+    "description": "Descripción del producto",
+    "short_description": "Descripción corta",
+    "sku": "PROD-001",
+    "categories": [
+        {"id": 15}
+    ],
+    "images": [
+        {"src": "https://example.com/image1.jpg"}
+    ],
+    "warehouse_id": 1,
+    "warehouse_quantity": 100,
+    "warehouse_price": 29.99,
+    "condicion": "new",
+    "currency_id": "CLP",
+    "listing_type_id": "gold_special",
+    "category_id": "MLB1234",
+    "warehouse_attribute": {
+        "color": "rojo",
+        "size": "M"
+    },
+    "warehouse_pictures": [
+        {"src": "https://example.com/image1.jpg"}
+    ],
+    "warehouse_sale_terms": [
+        {"id": "WARRANTY_TYPE", "value_name": "Garantía del vendedor"}
+    ],
+    "warehouse_shipping": {
+        "mode": "me2",
+        "free_shipping": true
+    },
+    "warehouse_description": "Descripción para la bodega"
+}
+```
+
+#### 1.3 Obtener Productos por Bodega
+**Endpoint:** `GET /api/woocommerce/woo/{storeId}/warehouse/{warehouseId}/products`
+
+Obtiene todos los productos de WooCommerce asignados a una bodega específica.
+
+**Parámetros de URL:**
+- `storeId`: ID de la tienda WooCommerce
+- `warehouseId`: ID de la bodega
+
+**Respuesta exitosa:**
+```json
+{
+    "warehouse": {
+        "id": 1,
+        "name": "Bodega Principal",
+        "location": "Santiago",
+        "company": {
+            "id": 1,
+            "name": "Empresa Ejemplo"
+        }
+    },
+    "products": [
+        {
+            "id": 12345,
+            "name": "Producto Ejemplo",
+            "type": "simple",
+            "status": "publish",
+            "price": "29.99",
+            "stock_warehouse_id": 1,
+            "warehouse_quantity": 100,
+            "warehouse_price": 29.99,
+            "warehouse_condicion": "new",
+            "warehouse_currency_id": "CLP",
+            "warehouse_listing_type_id": "gold_special"
+        }
+    ],
+    "total_count": 1,
+    "status": "success"
+}
+```
+
+### 2. Gestión de Stock en Bodegas
+
+#### 2.1 Obtener Todo el Stock de Bodegas
+**Endpoint:** `GET /api/stock/warehouse`
+
+Obtiene todo el stock de productos en todas las bodegas.
+
+**Respuesta exitosa:**
+```json
+{
+    "message": "Stock de bodegas obtenido correctamente",
+    "warehouse_stock": [
+        {
+            "id": 1,
+            "id_mlc": "12345",
+            "warehouse_id": 1,
+            "title": "Producto Ejemplo",
+            "price": 29.99,
+            "available_quantity": 100,
+            "warehouse": {
+                "id": 1,
+                "name": "Bodega Principal",
+                "company": {
+                    "id": 1,
+                    "name": "Empresa Ejemplo"
+                }
+            }
+        }
+    ],
+    "status": "success"
+}
+```
+
+#### 2.2 Obtener Stock de Bodega Específica
+**Endpoint:** `GET /api/stock/warehouse/{warehouseId}`
+
+Obtiene el stock de una bodega específica.
+
+**Parámetros de URL:**
+- `warehouseId`: ID de la bodega
+
+#### 2.3 Crear Stock en Bodega
+**Endpoint:** `POST /api/stock/warehouse`
+
+Crea un nuevo registro de stock en una bodega.
+
+**Body de la petición:**
+```json
+{
+    "id_mlc": "12345",
+    "warehouse_id": 1,
+    "title": "Producto Ejemplo",
+    "price": 29.99,
+    "available_quantity": 100,
+    "condicion": "new",
+    "currency_id": "CLP",
+    "listing_type_id": "gold_special",
+    "category_id": "MLB1234",
+    "attribute": {
+        "color": "rojo",
+        "size": "M"
+    },
+    "pictures": [
+        {"src": "https://example.com/image1.jpg"}
+    ],
+    "sale_terms": [
+        {"id": "WARRANTY_TYPE", "value_name": "Garantía del vendedor"}
+    ],
+    "shipping": {
+        "mode": "me2",
+        "free_shipping": true
+    },
+    "description": "Descripción del producto"
+}
+```
+
+#### 2.4 Actualizar Stock en Bodega
+**Endpoint:** `PUT /api/stock/warehouse/{stockId}`
+
+Actualiza el stock de un producto en una bodega.
+
+**Parámetros de URL:**
+- `stockId`: ID del registro de stock
+
+**Body de la petición:**
+```json
+{
+    "available_quantity": 150,
+    "price": 34.99,
+    "condicion": "new",
+    "currency_id": "CLP",
+    "listing_type_id": "gold_special"
+}
+```
+
+#### 2.5 Eliminar Stock de Bodega
+**Endpoint:** `DELETE /api/stock/warehouse/{stockId}`
+
+Elimina un registro de stock de una bodega.
+
+**Parámetros de URL:**
+- `stockId`: ID del registro de stock
+
+#### 2.6 Obtener Stock por Empresa
+**Endpoint:** `GET /api/stock/company/{companyId}`
+
+Obtiene todo el stock de productos de una empresa específica.
+
+**Parámetros de URL:**
+- `companyId`: ID de la empresa
+
+## Estructura de Datos
+
+### Modelo StockWarehouse
+```php
+protected $fillable = [
+    'id_mlc',           // ID del producto en WooCommerce/MercadoLibre
+    'title',            // Título del producto
+    'price',            // Precio del producto
+    'condicion',        // Condición del producto (new, used, etc.)
+    'currency_id',      // ID de la moneda
+    'listing_type_id',  // ID del tipo de listado
+    'available_quantity', // Cantidad disponible
+    'warehouse_id',     // ID de la bodega
+    'category_id',      // ID de la categoría
+    'attribute',        // Atributos del producto (JSON)
+    'pictures',         // Imágenes del producto (JSON)
+    'sale_terms',       // Términos de venta (JSON)
+    'shipping',         // Información de envío (JSON)
+    'description',      // Descripción del producto
+];
+```
+
+### Relaciones
+- `StockWarehouse` pertenece a `Warehouse`
+- `StockWarehouse` tiene muchos `ProductSale`
+- `StockWarehouse` tiene una relación a través de `Warehouse` con `Company`
+
+## Casos de Uso
+
+### 1. Crear Producto en WooCommerce y Asignar a Bodega
+1. Usar el endpoint `POST /api/woocommerce/woo/{storeId}/product-create-assign-warehouse`
+2. Proporcionar datos del producto WooCommerce y datos de asignación a bodega
+3. El sistema creará el producto en WooCommerce y lo registrará en la tabla `stock_warehouses`
+
+### 2. Asignar Producto Existente a Bodega
+1. Usar el endpoint `POST /api/woocommerce/woo/{storeId}/product/{productId}/assign-warehouse`
+2. Proporcionar datos de asignación a bodega
+3. El sistema registrará el producto existente en la tabla `stock_warehouses`
+
+### 3. Gestionar Stock de Productos
+1. Usar los endpoints del `StockController` para CRUD de stock
+2. Actualizar cantidades, precios y otros datos según sea necesario
+3. Consultar stock por bodega, empresa o globalmente
+
+## Validaciones
+
+### WooCommerce
+- Validación de conexión a la tienda
+- Validación de datos del producto según el tipo
+- Validación de precios y cantidades
+
+### Bodegas
+- Validación de existencia de bodega
+- Validación de datos de stock
+- Validación de relaciones con empresas
+
+### Stock
+- Validación de cantidades mínimas
+- Validación de precios positivos
+- Validación de campos requeridos
+
+## Logs y Monitoreo
+
+Todos los endpoints incluyen logging detallado para:
+- Inicio de operaciones
+- Validaciones fallidas
+- Errores de API
+- Operaciones exitosas
+- Información de debugging
+
+## Manejo de Errores
+
+Los endpoints manejan los siguientes tipos de errores:
+- Errores de validación (422)
+- Errores de WooCommerce API (400)
+- Errores de base de datos (500)
+- Recursos no encontrados (404)
+- Errores de autenticación (401)
+
+## Autenticación
+
+Todos los endpoints requieren autenticación mediante Sanctum:
+- Middleware: `auth:sanctum`
+- Token de acceso requerido en headers
+- Logging de usuario autenticado 

--- a/multistock-backend/app/Http/Controllers/StockController.php
+++ b/multistock-backend/app/Http/Controllers/StockController.php
@@ -4,7 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Models\StockProducto;
 use App\Models\Producto;
+use App\Models\StockWarehouse;
+use App\Models\Warehouse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class StockController extends Controller
 {
@@ -79,5 +82,280 @@ class StockController extends Controller
         return response()->json([
             'message' => 'Stock eliminado correctamente'
         ], 200);
+    }
+
+    /**
+     * Obtener stock de productos en bodegas
+     */
+    public function getWarehouseStock()
+    {
+        try {
+            $warehouseStock = StockWarehouse::with(['warehouse', 'warehouse.company'])->get();
+
+            return response()->json([
+                'message' => 'Stock de bodegas obtenido correctamente',
+                'warehouse_stock' => $warehouseStock,
+                'status' => 'success'
+            ], 200);
+        } catch (\Exception $e) {
+            Log::error('Error al obtener stock de bodegas', [
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error al obtener stock de bodegas',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 500);
+        }
+    }
+
+    /**
+     * Obtener stock de una bodega específica
+     */
+    public function getStockByWarehouse($warehouseId)
+    {
+        try {
+            $warehouse = Warehouse::with('company')->findOrFail($warehouseId);
+            $stock = StockWarehouse::where('warehouse_id', $warehouseId)->get();
+
+            return response()->json([
+                'message' => 'Stock de bodega obtenido correctamente',
+                'warehouse' => $warehouse,
+                'stock' => $stock,
+                'total_items' => $stock->count(),
+                'status' => 'success'
+            ], 200);
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            return response()->json([
+                'message' => 'Bodega no encontrada',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 404);
+        } catch (\Exception $e) {
+            Log::error('Error al obtener stock de bodega', [
+                'warehouse_id' => $warehouseId,
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error al obtener stock de bodega',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 500);
+        }
+    }
+
+    /**
+     * Actualizar stock de un producto en bodega
+     */
+    public function updateWarehouseStock(Request $request, $stockId)
+    {
+        try {
+            $stock = StockWarehouse::findOrFail($stockId);
+
+            $validated = $request->validate([
+                'available_quantity' => 'sometimes|integer|min:0',
+                'price' => 'sometimes|numeric|min:0',
+                'condicion' => 'sometimes|string|max:255',
+                'currency_id' => 'sometimes|string|max:255',
+                'listing_type_id' => 'sometimes|string|max:255',
+                'category_id' => 'nullable|string|max:255',
+                'attribute' => 'nullable|array',
+                'pictures' => 'nullable|array',
+                'sale_terms' => 'nullable|array',
+                'shipping' => 'nullable|array',
+                'description' => 'nullable|string'
+            ]);
+
+            if (empty(array_filter($validated))) {
+                return response()->json([
+                    'message' => 'Debes enviar al menos un campo para actualizar.',
+                    'fields' => ['available_quantity', 'price', 'condicion', 'currency_id', 'listing_type_id', 'category_id', 'attribute', 'pictures', 'sale_terms', 'shipping', 'description']
+                ], 422);
+            }
+
+            // Procesar campos JSON
+            if (isset($validated['attribute'])) {
+                $validated['attribute'] = json_encode($validated['attribute']);
+            }
+            if (isset($validated['pictures'])) {
+                $validated['pictures'] = json_encode($validated['pictures']);
+            }
+            if (isset($validated['sale_terms'])) {
+                $validated['sale_terms'] = json_encode($validated['sale_terms']);
+            }
+            if (isset($validated['shipping'])) {
+                $validated['shipping'] = json_encode($validated['shipping']);
+            }
+
+            $stock->update(array_filter($validated));
+
+            Log::info('Stock de bodega actualizado', [
+                'stock_id' => $stockId,
+                'updated_fields' => array_keys(array_filter($validated))
+            ]);
+
+            return response()->json([
+                'message' => 'Stock de bodega actualizado correctamente',
+                'stock' => $stock->fresh(),
+                'status' => 'success'
+            ], 200);
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            return response()->json([
+                'message' => 'Stock no encontrado',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 404);
+        } catch (\Exception $e) {
+            Log::error('Error al actualizar stock de bodega', [
+                'stock_id' => $stockId,
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error al actualizar stock de bodega',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 500);
+        }
+    }
+
+    /**
+     * Crear stock de producto en bodega
+     */
+    public function createWarehouseStock(Request $request)
+    {
+        try {
+            $validated = $request->validate([
+                'id_mlc' => 'nullable|string|max:255',
+                'warehouse_id' => 'required|integer|exists:warehouses,id',
+                'title' => 'required|string|max:255',
+                'price' => 'required|numeric|min:0',
+                'available_quantity' => 'required|integer|min:0',
+                'condicion' => 'required|string|max:255',
+                'currency_id' => 'required|string|max:255',
+                'listing_type_id' => 'required|string|max:255',
+                'category_id' => 'nullable|string|max:255',
+                'attribute' => 'nullable|array',
+                'pictures' => 'nullable|array',
+                'sale_terms' => 'nullable|array',
+                'shipping' => 'nullable|array',
+                'description' => 'nullable|string'
+            ]);
+
+            // Crear producto en bodega
+            $stock = StockWarehouse::create([
+                'id_mlc' => $validated['id_mlc'] ?? null,
+                'warehouse_id' => $validated['warehouse_id'],
+                'title' => $validated['title'],
+                'price' => $validated['price'],
+                'condicion' => $validated['condicion'],
+                'currency_id' => $validated['currency_id'],
+                'listing_type_id' => $validated['listing_type_id'],
+                'available_quantity' => $validated['available_quantity'],
+                'category_id' => $validated['category_id'] ?? null,
+                'attribute' => isset($validated['attribute']) ? json_encode($validated['attribute']) : json_encode([]),
+                'pictures' => isset($validated['pictures']) ? json_encode($validated['pictures']) : json_encode([]),
+                'sale_terms' => isset($validated['sale_terms']) ? json_encode($validated['sale_terms']) : json_encode([]),
+                'shipping' => isset($validated['shipping']) ? json_encode($validated['shipping']) : json_encode([]),
+                'description' => $validated['description'] ?? '',
+            ]);
+
+            Log::info('Stock de bodega creado', [
+                'stock_id' => $stock->id,
+                'warehouse_id' => $validated['warehouse_id'],
+                'title' => $validated['title']
+            ]);
+
+            return response()->json([
+                'message' => 'Stock de bodega creado correctamente',
+                'stock' => $stock->load('warehouse'),
+                'status' => 'success'
+            ], 201);
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            return response()->json([
+                'message' => 'Datos inválidos.',
+                'errors' => $e->errors(),
+                'status' => 'error'
+            ], 422);
+        } catch (\Exception $e) {
+            Log::error('Error al crear stock de bodega', [
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error al crear stock de bodega',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 500);
+        }
+    }
+
+    /**
+     * Eliminar stock de producto en bodega
+     */
+    public function deleteWarehouseStock($stockId)
+    {
+        try {
+            $stock = StockWarehouse::findOrFail($stockId);
+            $stock->delete();
+
+            Log::info('Stock de bodega eliminado', [
+                'stock_id' => $stockId
+            ]);
+
+            return response()->json([
+                'message' => 'Stock de bodega eliminado correctamente',
+                'status' => 'success'
+            ], 200);
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            return response()->json([
+                'message' => 'Stock no encontrado',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 404);
+        } catch (\Exception $e) {
+            Log::error('Error al eliminar stock de bodega', [
+                'stock_id' => $stockId,
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error al eliminar stock de bodega',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 500);
+        }
+    }
+
+    /**
+     * Obtener stock por empresa
+     */
+    public function getStockByCompany($companyId)
+    {
+        try {
+            $stock = StockWarehouse::whereHas('warehouse', function($query) use ($companyId) {
+                $query->where('assigned_company_id', $companyId);
+            })->with(['warehouse', 'warehouse.company'])->get();
+
+            return response()->json([
+                'message' => 'Stock por empresa obtenido correctamente',
+                'stock' => $stock,
+                'total_items' => $stock->count(),
+                'status' => 'success'
+            ], 200);
+        } catch (\Exception $e) {
+            Log::error('Error al obtener stock por empresa', [
+                'company_id' => $companyId,
+                'message' => $e->getMessage(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error al obtener stock por empresa',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 500);
+        }
     }
 }

--- a/multistock-backend/app/Http/Controllers/Woocommerce/WooProductController.php
+++ b/multistock-backend/app/Http/Controllers/Woocommerce/WooProductController.php
@@ -845,4 +845,388 @@ class WooProductController extends Controller
             ], 500);
         }
     }
+
+    /**
+     * Asignar un producto de WooCommerce a una bodega
+     */
+    public function assignProductToWarehouse(Request $request, $storeId, $productId)
+    {
+        Log::info('Iniciando asignación de producto a bodega', [
+            'storeId' => $storeId,
+            'productId' => $productId,
+            'request_data' => $request->all(),
+            'user_id' => auth()->id() ?? 'no_authenticated'
+        ]);
+
+        try {
+            $woocommerce = $this->connect($storeId);
+            
+            // Validar datos de entrada
+            $validator = Validator::make($request->all(), [
+                'warehouse_id' => 'required|integer|exists:warehouses,id',
+                'available_quantity' => 'required|integer|min:0',
+                'price' => 'required|numeric|min:0',
+                'condicion' => 'required|string|max:255',
+                'currency_id' => 'required|string|max:255',
+                'listing_type_id' => 'required|string|max:255',
+                'category_id' => 'nullable|string|max:255',
+                'attribute' => 'nullable|array',
+                'pictures' => 'nullable|array',
+                'sale_terms' => 'nullable|array',
+                'shipping' => 'nullable|array',
+                'description' => 'nullable|string'
+            ]);
+
+            if ($validator->fails()) {
+                Log::warning('Validación fallida al asignar producto a bodega', [
+                    'errors' => $validator->errors(),
+                    'request_data' => $request->all(),
+                    'storeId' => $storeId,
+                    'productId' => $productId
+                ]);
+                return response()->json([
+                    'message' => 'Error de validación.',
+                    'errors' => $validator->errors(),
+                    'status' => 'error'
+                ], 422);
+            }
+
+            // Obtener el producto de WooCommerce
+            $wooProduct = $woocommerce->get("products/{$productId}");
+            
+            if (!$wooProduct) {
+                return response()->json([
+                    'message' => 'Producto de WooCommerce no encontrado.',
+                    'status' => 'error'
+                ], 404);
+            }
+
+            $data = $validator->validated();
+
+            // Crear registro en stock_warehouses
+            $stockWarehouse = \App\Models\StockWarehouse::create([
+                'id_mlc' => $wooProduct->id, // Usar el ID de WooCommerce como id_mlc
+                'warehouse_id' => $data['warehouse_id'],
+                'title' => $wooProduct->name,
+                'price' => $data['price'],
+                'condicion' => $data['condicion'],
+                'currency_id' => $data['currency_id'],
+                'listing_type_id' => $data['listing_type_id'],
+                'available_quantity' => $data['available_quantity'],
+                'category_id' => $data['category_id'] ?? null,
+                'attribute' => isset($data['attribute']) ? json_encode($data['attribute']) : json_encode([]),
+                'pictures' => isset($data['pictures']) ? json_encode($data['pictures']) : json_encode($wooProduct->images ?? []),
+                'sale_terms' => isset($data['sale_terms']) ? json_encode($data['sale_terms']) : json_encode([]),
+                'shipping' => isset($data['shipping']) ? json_encode($data['shipping']) : json_encode([]),
+                'description' => $data['description'] ?? $wooProduct->description ?? '',
+            ]);
+
+            Log::info('Producto asignado exitosamente a bodega', [
+                'stock_warehouse_id' => $stockWarehouse->id,
+                'warehouse_id' => $data['warehouse_id'],
+                'woo_product_id' => $productId,
+                'storeId' => $storeId
+            ]);
+
+            return response()->json([
+                'message' => 'Producto asignado correctamente a la bodega.',
+                'stock_warehouse' => $stockWarehouse,
+                'woo_product' => $this->filterProductResponse($wooProduct, $woocommerce),
+                'status' => 'success'
+            ], 201);
+
+        } catch (\Automattic\WooCommerce\HttpClient\HttpClientException $e) {
+            Log::error('Error de WooCommerce API al asignar producto a bodega', [
+                'message' => $e->getMessage(),
+                'code' => $e->getCode(),
+                'storeId' => $storeId,
+                'productId' => $productId,
+                'request_data' => $request->all(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error de WooCommerce API.',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 400);
+        } catch (\Exception $e) {
+            Log::error('Error general al asignar producto a bodega', [
+                'message' => $e->getMessage(),
+                'code' => $e->getCode(),
+                'storeId' => $storeId,
+                'productId' => $productId,
+                'request_data' => $request->all(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error al asignar el producto a la bodega.',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 500);
+        }
+    }
+
+    /**
+     * Crear producto en WooCommerce y asignarlo a una bodega en una sola operación
+     */
+    public function createProductAndAssignToWarehouse(Request $request, $storeId)
+    {
+        Log::info('Iniciando creación de producto y asignación a bodega', [
+            'storeId' => $storeId,
+            'request_data' => $request->all(),
+            'user_id' => auth()->id() ?? 'no_authenticated'
+        ]);
+
+        try {
+            $woocommerce = $this->connect($storeId);
+
+            // Validación de datos de entrada
+            $validator = Validator::make($request->all(), [
+                // Datos del producto WooCommerce
+                'name' => 'required|string|max:255',
+                'type' => 'sometimes|in:simple,grouped,external,variable',
+                'regular_price' => 'sometimes|numeric|min:0',
+                'sale_price' => 'sometimes|numeric|min:0',
+                'description' => 'sometimes|string',
+                'short_description' => 'sometimes|string',
+                'sku' => 'sometimes|string|max:100',
+                'manage_stock' => 'sometimes|boolean',
+                'stock_quantity' => 'sometimes|integer|min:0',
+                'stock_status' => 'sometimes|in:instock,outofstock,onbackorder',
+                'weight' => 'sometimes|numeric|min:0',
+                'dimensions.length' => 'sometimes|numeric|min:0',
+                'dimensions.width' => 'sometimes|numeric|min:0',
+                'dimensions.height' => 'sometimes|numeric|min:0',
+                'categories' => 'sometimes|array',
+                'categories.*.id' => 'required_with:categories|integer',
+                'tags' => 'sometimes|array',
+                'tags.*.id' => 'required_with:tags|integer',
+                'images' => 'sometimes|array',
+                'images.*.src' => 'required_with:images|url',
+                'attributes' => 'sometimes|array',
+                'status' => 'sometimes|in:draft,pending,private,publish',
+                'featured' => 'sometimes|boolean',
+                'catalog_visibility' => 'sometimes|in:visible,catalog,search,hidden',
+                'virtual' => 'sometimes|boolean',
+                'downloadable' => 'sometimes|boolean',
+                'external_url' => 'sometimes|url',
+                'button_text' => 'sometimes|string|max:255',
+                'tax_status' => 'sometimes|in:taxable,shipping,none',
+                'tax_class' => 'sometimes|string',
+                'reviews_allowed' => 'sometimes|boolean',
+                'purchase_note' => 'sometimes|string',
+                'menu_order' => 'sometimes|integer',
+                
+                // Datos de asignación a bodega
+                'warehouse_id' => 'required|integer|exists:warehouses,id',
+                'warehouse_quantity' => 'required|integer|min:0',
+                'warehouse_price' => 'required|numeric|min:0',
+                'condicion' => 'required|string|max:255',
+                'currency_id' => 'required|string|max:255',
+                'listing_type_id' => 'required|string|max:255',
+                'category_id' => 'nullable|string|max:255',
+                'warehouse_attribute' => 'nullable|array',
+                'warehouse_pictures' => 'nullable|array',
+                'warehouse_sale_terms' => 'nullable|array',
+                'warehouse_shipping' => 'nullable|array',
+                'warehouse_description' => 'nullable|string'
+            ]);
+
+            if ($validator->fails()) {
+                Log::warning('Validación fallida al crear producto y asignar a bodega', [
+                    'errors' => $validator->errors(),
+                    'request_data' => $request->all(),
+                    'storeId' => $storeId
+                ]);
+                return response()->json([
+                    'message' => 'Error de validación.',
+                    'errors' => $validator->errors(),
+                    'status' => 'error'
+                ], 422);
+            }
+
+            $data = $validator->validated();
+
+            // Separar datos del producto WooCommerce
+            $wooProductData = array_intersect_key($data, array_flip([
+                'name', 'type', 'regular_price', 'sale_price', 'description', 'short_description',
+                'sku', 'manage_stock', 'stock_quantity', 'stock_status', 'weight', 'dimensions',
+                'categories', 'tags', 'images', 'attributes', 'status', 'featured',
+                'catalog_visibility', 'virtual', 'downloadable', 'external_url', 'button_text',
+                'tax_status', 'tax_class', 'reviews_allowed', 'purchase_note', 'menu_order'
+            ]));
+
+            // Campos por defecto para un nuevo producto
+            $productData = array_merge([
+                'type' => 'simple',
+                'status' => 'publish',
+                'featured' => false,
+                'catalog_visibility' => 'visible',
+                'manage_stock' => false,
+                'stock_status' => 'instock',
+                'virtual' => false,
+                'downloadable' => false,
+                'reviews_allowed' => true,
+                'tax_status' => 'taxable',
+            ], $wooProductData);
+
+            // Crear el producto en WooCommerce
+            Log::info('Creando producto en WooCommerce', [
+                'productData' => $productData,
+                'storeId' => $storeId
+            ]);
+            
+            $created = $woocommerce->post("products", $productData);
+
+            Log::info('Producto creado exitosamente en WooCommerce', [
+                'created_product' => $created,
+                'storeId' => $storeId
+            ]);
+
+            // Crear registro en stock_warehouses
+            $stockWarehouse = \App\Models\StockWarehouse::create([
+                'id_mlc' => $created->id, // Usar el ID de WooCommerce como id_mlc
+                'warehouse_id' => $data['warehouse_id'],
+                'title' => $created->name,
+                'price' => $data['warehouse_price'],
+                'condicion' => $data['condicion'],
+                'currency_id' => $data['currency_id'],
+                'listing_type_id' => $data['listing_type_id'],
+                'available_quantity' => $data['warehouse_quantity'],
+                'category_id' => $data['category_id'] ?? null,
+                'attribute' => isset($data['warehouse_attribute']) ? json_encode($data['warehouse_attribute']) : json_encode([]),
+                'pictures' => isset($data['warehouse_pictures']) ? json_encode($data['warehouse_pictures']) : json_encode($created->images ?? []),
+                'sale_terms' => isset($data['warehouse_sale_terms']) ? json_encode($data['warehouse_sale_terms']) : json_encode([]),
+                'shipping' => isset($data['warehouse_shipping']) ? json_encode($data['warehouse_shipping']) : json_encode([]),
+                'description' => $data['warehouse_description'] ?? $created->description ?? '',
+            ]);
+
+            Log::info('Producto asignado exitosamente a bodega', [
+                'stock_warehouse_id' => $stockWarehouse->id,
+                'warehouse_id' => $data['warehouse_id'],
+                'woo_product_id' => $created->id,
+                'storeId' => $storeId
+            ]);
+
+            // Respuesta filtrada con información relevante
+            $filtered = $this->filterProductResponse($created, $woocommerce);
+
+            return response()->json([
+                'message' => 'Producto creado y asignado correctamente a la bodega.',
+                'created_product' => $filtered,
+                'stock_warehouse' => $stockWarehouse,
+                'status' => 'success'
+            ], 201);
+
+        } catch (\Automattic\WooCommerce\HttpClient\HttpClientException $e) {
+            Log::error('Error de WooCommerce API al crear producto y asignar a bodega', [
+                'message' => $e->getMessage(),
+                'code' => $e->getCode(),
+                'storeId' => $storeId,
+                'request_data' => $request->all(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error de WooCommerce API.',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 400);
+        } catch (\Exception $e) {
+            Log::error('Error general al crear producto y asignar a bodega', [
+                'message' => $e->getMessage(),
+                'code' => $e->getCode(),
+                'storeId' => $storeId,
+                'request_data' => $request->all(),
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error al crear el producto y asignarlo a la bodega.',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 500);
+        }
+    }
+
+    /**
+     * Obtener productos de WooCommerce asignados a una bodega específica
+     */
+    public function getProductsByWarehouse($storeId, $warehouseId)
+    {
+        Log::info('Obteniendo productos de WooCommerce por bodega', [
+            'storeId' => $storeId,
+            'warehouseId' => $warehouseId,
+            'user_id' => auth()->id() ?? 'no_authenticated'
+        ]);
+
+        try {
+            // Verificar que la bodega existe
+            $warehouse = \App\Models\Warehouse::findOrFail($warehouseId);
+            
+            // Obtener productos de la bodega
+            $stockWarehouses = \App\Models\StockWarehouse::where('warehouse_id', $warehouseId)->get();
+            
+            $woocommerce = $this->connect($storeId);
+            $products = [];
+
+            foreach ($stockWarehouses as $stockWarehouse) {
+                try {
+                    // Obtener producto de WooCommerce usando el id_mlc
+                    $wooProduct = $woocommerce->get("products/{$stockWarehouse->id_mlc}");
+                    $filteredProduct = $this->filterProductResponse($wooProduct, $woocommerce);
+                    
+                    // Combinar datos del producto WooCommerce con datos de stock
+                    $products[] = array_merge($filteredProduct, [
+                        'stock_warehouse_id' => $stockWarehouse->id,
+                        'warehouse_quantity' => $stockWarehouse->available_quantity,
+                        'warehouse_price' => $stockWarehouse->price,
+                        'warehouse_condicion' => $stockWarehouse->condicion,
+                        'warehouse_currency_id' => $stockWarehouse->currency_id,
+                        'warehouse_listing_type_id' => $stockWarehouse->listing_type_id,
+                    ]);
+                } catch (\Exception $e) {
+                    Log::warning('Error al obtener producto de WooCommerce', [
+                        'id_mlc' => $stockWarehouse->id_mlc,
+                        'error' => $e->getMessage()
+                    ]);
+                    // Continuar con el siguiente producto
+                }
+            }
+
+            Log::info('Productos obtenidos exitosamente', [
+                'warehouseId' => $warehouseId,
+                'products_count' => count($products),
+                'storeId' => $storeId
+            ]);
+
+            return response()->json([
+                'warehouse' => $warehouse,
+                'products' => $products,
+                'total_count' => count($products),
+                'status' => 'success'
+            ]);
+
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            Log::error('Bodega no encontrada', [
+                'warehouseId' => $warehouseId,
+                'error' => $e->getMessage()
+            ]);
+            return response()->json([
+                'message' => 'Bodega no encontrada.',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 404);
+        } catch (\Exception $e) {
+            Log::error('Error al obtener productos por bodega', [
+                'message' => $e->getMessage(),
+                'warehouseId' => $warehouseId,
+                'storeId' => $storeId,
+                'trace' => $e->getTraceAsString()
+            ]);
+            return response()->json([
+                'message' => 'Error al obtener productos por bodega.',
+                'error' => $e->getMessage(),
+                'status' => 'error'
+            ], 500);
+        }
+    }
 }

--- a/multistock-backend/routes/api.php
+++ b/multistock-backend/routes/api.php
@@ -203,6 +203,14 @@ Route::middleware(['auth:sanctum', 'role:admin,finanzas'])->group(function () {
     Route::delete('/warehouse-stock/{id}', [warehouseDeleteStockController::class, 'stock_delete']); // Eliminar stock
     Route::get('/warehouse/{warehouse_id}/stock', [warehouseGetStockByWarehouseController::class, 'getStockByWarehouse']); // Obtener stock por bodega
     Route::post('/warehouse-stock-masive/{warehouseId}', [warehouseCreateMasiveProductStockController::class, 'warehouseCreateMasiveProductStock']); // Crear stock masivo
+    
+    // STOCK CONTROLLER - GESTIÓN DE STOCK EN BODEGAS
+    Route::get('/stock/warehouse', [StockController::class, 'getWarehouseStock']); // Obtener todo el stock de bodegas
+    Route::get('/stock/warehouse/{warehouseId}', [StockController::class, 'getStockByWarehouse']); // Obtener stock de bodega específica
+    Route::post('/stock/warehouse', [StockController::class, 'createWarehouseStock']); // Crear stock en bodega
+    Route::put('/stock/warehouse/{stockId}', [StockController::class, 'updateWarehouseStock']); // Actualizar stock en bodega
+    Route::delete('/stock/warehouse/{stockId}', [StockController::class, 'deleteWarehouseStock']); // Eliminar stock de bodega
+    Route::get('/stock/company/{companyId}', [StockController::class, 'getStockByCompany']); // Obtener stock por empresa
 
     // COMPARACIÓN DE STOCK
     Route::get('/compare-stock/{id_mlc}/{idCompany}', [getCompareStockByProductiDController::class, 'getCompareStockByProductiD']);// Comparar stock por ID_MLC y empresa
@@ -335,6 +343,11 @@ Route::middleware(['auth:sanctum', 'role:admin,finanzas'])->group(function () {
     Route::get('/woocommerce/woo/{storeId}/product/{productId}', [WooProductController::class, 'getProduct']);
     Route::get('/woocommerce/woo/{storeId}/productc-list', [WooProductController::class, 'listProducts']);//listar productos de WooCommerce
     Route::get('/woocommerce/woo/{storeId}/variable-products', [WooProductController::class, 'listVariableProducts']);//listar solo productos variables
+    
+    // ASIGNACIÓN DE PRODUCTOS A BODEGAS
+    Route::post('/woocommerce/woo/{storeId}/product/{productId}/assign-warehouse', [WooProductController::class, 'assignProductToWarehouse']);// Asignar producto existente a bodega
+    Route::post('/woocommerce/woo/{storeId}/product-create-assign-warehouse', [WooProductController::class, 'createProductAndAssignToWarehouse']);// Crear producto y asignar a bodega
+    Route::get('/woocommerce/woo/{storeId}/warehouse/{warehouseId}/products', [WooProductController::class, 'getProductsByWarehouse']);// Obtener productos por bodega
     //categorias wooComerce
     Route::Get('/woocommerce/woo/{storeId}/categories', [WooCategoryController::class, 'listCategories']);
     Route::Get('/woocommerce/woo/{storeId}/category/{categoryId}',[WooCategoryController::class, 'getCategory']);


### PR DESCRIPTION
- Agregar métodos en WooProductController para asignar productos a bodegas
- Implementar createProductAndAssignToWarehouse para crear y asignar en una operación
- Agregar getProductsByWarehouse para consultar productos por bodega
- Actualizar StockController con métodos para gestión de stock en bodegas
- Agregar nuevas rutas API para WooCommerce + bodegas y gestión de stock
- Crear documentación completa en README_WOOCOMMERCE_WAREHOUSE.md
- Incluir validaciones, manejo de errores y logging detallado